### PR TITLE
Adding new besluit type and document type

### DIFF
--- a/codelijsten/besluit-type.ttl
+++ b/codelijsten/besluit-type.ttl
@@ -568,6 +568,27 @@ gemeentebedrijf.""";
   <http://www.w3.org/2004/02/skos/core#prefLabel> "Andere" ;
   <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitType> .
 
+<https://data.vlaanderen.be/id/concept/BesluitType/df483116-be05-4a2b-a68a-baf355c9bd81> a <http://www.w3.org/2004/02/skos/core#Concept>,
+    <http://www.w3.org/2000/01/rdf-schema#Class>;
+  <http://www.w3.org/2004/02/skos/core#definition> "Definitieve beslissing tot fusie: de gemeenten keuren het gezamenlijke fusievoorstel goed als ze op basis van de resultaten van het voorbereidend onderzoek effectief tot een fusie willen overgaan.";
+  <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitType>;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "Gezamenlijk voorstel tot fusie" ;
+  <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitType> .
+
+<https://data.vlaanderen.be/id/concept/BesluitType/d85218e2-a75f-4a30-9182-512b5c9dd1b2> a <http://www.w3.org/2004/02/skos/core#Concept>,
+    <http://www.w3.org/2000/01/rdf-schema#Class>;
+  <http://www.w3.org/2004/02/skos/core#definition> "Budget(wijziging) - Indiening bij toezichthoudende gemeente of provincie.";
+  <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitType>;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "Budget(wijziging) - Indiening bij toezichthoudende gemeente of provincie" ;
+  <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitType> .
+
+<https://data.vlaanderen.be/id/concept/BesluitType/d463b6d1-c207-4c1a-8c08-f2c7dd1fa53b> a <http://www.w3.org/2004/02/skos/core#Concept>,
+    <http://www.w3.org/2000/01/rdf-schema#Class>;
+  <http://www.w3.org/2004/02/skos/core#definition> "Budget(wijziging) - Indiening bij centraal bestuur of representatief orgaan.";
+  <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitType>;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "Budget(wijziging) - Indiening bij centraal bestuur of representatief orgaan" ;
+  <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitType> .
+
 <https://data.vlaanderen.be/id/conceptscheme/BesluitType> a <http://www.w3.org/2004/02/skos/core#ConceptScheme>;
   <http://www.w3.org/2004/02/skos/core#definition> "Het type van de rechtsgrond. Bijvoorbeeld: reglement, wet, voorstel.";
   <http://www.w3.org/2004/02/skos/core#prefLabel> "besluit type" .

--- a/codelijsten/document-type.ttl
+++ b/codelijsten/document-type.ttl
@@ -48,6 +48,41 @@
   <http://www.w3.org/2004/02/skos/core#prefLabel> "Overzicht vergoedingen en presentiegelden";
   <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType> .
 
+<https://data.vlaanderen.be/id/concept/BesluitDocumentType/3a3ea43f-6631-4a7d-94c6-3a77a445d450> a <http://www.w3.org/2004/02/skos/core#Concept>,
+    <http://www.w3.org/2000/01/rdf-schema#Class>;
+  <http://www.w3.org/2004/02/skos/core#definition> "Reactie op opvragen bijkomende inlichtingen door de toezichthouder (gemeente/provincie) aan de eredienstbesturen.";
+  <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType>;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "Reactie op opvragen bijkomende inlichtingen door de toezichthouder (gemeente/provincie) aan de eredienstbesturen";
+  <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType> .
+
+<https://data.vlaanderen.be/id/concept/BesluitDocumentType/4f938e44-8bce-4d3a-b5a7-b84754fe981a> a <http://www.w3.org/2004/02/skos/core#Concept>,
+    <http://www.w3.org/2000/01/rdf-schema#Class>;
+  <http://www.w3.org/2004/02/skos/core#definition> "Aanvraag desaffectatie presbyteria/kerken.";
+  <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType>;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "Aanvraag desaffectatie presbyteria/kerken";
+  <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType> .
+
+<https://data.vlaanderen.be/id/concept/BesluitDocumentType/24743b26-e0fb-4c14-8c82-5cd271289b0e> a <http://www.w3.org/2004/02/skos/core#Concept>,
+    <http://www.w3.org/2000/01/rdf-schema#Class>;
+  <http://www.w3.org/2004/02/skos/core#definition> "Opvragen bijkomende inlichtingen eredienstbesturen (met als gevolg stuiting termijn).";
+  <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType>;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "Opvragen bijkomende inlichtingen eredienstbesturen (met als gevolg stuiting termijn)";
+  <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType> .
+
+<https://data.vlaanderen.be/id/concept/BesluitDocumentType/ce569d3d-25ff-4ce9-a194-e77113597e29> a <http://www.w3.org/2004/02/skos/core#Concept>,
+    <http://www.w3.org/2000/01/rdf-schema#Class>;
+  <http://www.w3.org/2004/02/skos/core#definition> "Budgetten(wijzigingen) - Indiening bij toezichthoudende gemeente of provincie.";
+  <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType>;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "Budgetten(wijzigingen) - Indiening bij toezichthoudende gemeente of provincie";
+  <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType> .
+
+<https://data.vlaanderen.be/id/concept/BesluitDocumentType/18833df2-8c9e-4edd-87fd-b5c252337349> a <http://www.w3.org/2004/02/skos/core#Concept>,
+    <http://www.w3.org/2000/01/rdf-schema#Class>;
+  <http://www.w3.org/2004/02/skos/core#definition> "Budgetten(wijzigingen) - Indiening bij representatief orgaan.";
+  <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType>;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "Budgetten(wijzigingen) - Indiening bij representatief orgaan";
+  <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType> .
+
 <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType> a <http://www.w3.org/2004/02/skos/core#ConceptScheme>;
   <http://www.w3.org/2004/02/skos/core#definition> "Het type van het document. Bijvoorbeeld: besluitenlijst, agenda,....";
   <http://www.w3.org/2004/02/skos/core#prefLabel> "besluit document type" .


### PR DESCRIPTION
# Description

DL-5452

This PR adds missing besluit type and document type recently added in loket, toezicht ABB, publieke besluiten databank, erediensten databank, meldingsplichtige-api and centrale vindplaats.

BesluitDocumentType :

- "Reactie op opvragen bijkomende inlichtingen door de toezichthouder (gemeente/provincie) aan de eredienstbesturen" | UUID `3a3ea43f-6631-4a7d-94c6-3a77a445d450`

- "Aanvraag desaffectatie presbyteria/kerken" | UUID `4f938e44-8bce-4d3a-b5a7-b84754fe981a`

- "Opvragen bijkomende inlichtingen eredienstbesturen (met als gevolg stuiting termijn)" | UUID `24743b26-e0fb-4c14-8c82-5cd271289b0e`

- "Budgetten(wijzigingen) - Indiening bij representatief orgaan | UUID `18833df2-8c9e-4edd-87fd-b5c252337349`

- "Budgetten(wijzigingen) - Indiening bij toezichthoudende gemeente of provincie" | UUID `ce569d3d-25ff-4ce9-a194-e77113597e29`

BesluitType : 

- "Gezamenlijk voorstel tot fusie" | UUID `df483116-be05-4a2b-a68a-baf355c9bd81`

- "Budget(wijziging) - Indiening bij centraal bestuur of representatief orgaan"  | UUID `d463b6d1-c207-4c1a-8c08-f2c7dd1fa53b`

- "Budget(wijziging) - Indiening bij toezichthoudende gemeente of provincie" | UUID `d85218e2-a75f-4a30-9182-512b5c9dd1b2`

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

# Related services

- N/A

# How to test 

- N/A

# What to check

- N/A

# Links to other PR's

- https://github.com/lblod/app-centrale-vindplaats/pull/42
- https://github.com/lblod/app-digitaal-loket/pull/454

# Notes

N/A