### PR TITLE
Adding besluitDocumentTypes for new LEKP forms

### DIFF
--- a/codelijsten/document-type.ttl
+++ b/codelijsten/document-type.ttl
@@ -48,6 +48,27 @@
   <http://www.w3.org/2004/02/skos/core#prefLabel> "Overzicht vergoedingen en presentiegelden";
   <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType> .
 
+<https://data.vlaanderen.be/id/concept/BesluitDocumentType/fbe65218-836d-4e7a-a988-bb0b2cf26c7b> a <http://www.w3.org/2004/02/skos/core#Concept>,
+    <http://www.w3.org/2000/01/rdf-schema#Class>;
+  <http://www.w3.org/2004/02/skos/core#definition> "LEKP-rapport - Sloopbeleidsplan.";
+  <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType>;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "LEKP-rapport - Sloopbeleidsplan";
+  <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType> .
+
+<https://data.vlaanderen.be/id/concept/BesluitDocumentType/275b452e-8e9e-40c5-a1e1-4a34a9f04e62> a <http://www.w3.org/2004/02/skos/core#Concept>,
+    <http://www.w3.org/2000/01/rdf-schema#Class>;
+  <http://www.w3.org/2004/02/skos/core#definition> "LEKP-rapport - Collectieve-energiebesparende-renovatie.";
+  <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType>;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "LEKP-rapport - Collectieve-energiebesparende-renovatie";
+  <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType> .
+
+<https://data.vlaanderen.be/id/concept/BesluitDocumentType/62031aa8-2b35-48fd-9533-e76dc2cb040f> a <http://www.w3.org/2004/02/skos/core#Concept>,
+    <http://www.w3.org/2000/01/rdf-schema#Class>;
+  <http://www.w3.org/2004/02/skos/core#definition> "LEKP-rapport - Fietspaden.";
+  <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType>;
+  <http://www.w3.org/2004/02/skos/core#prefLabel> "LEKP-rapport - Fietspaden";
+  <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType> .
+
 <https://data.vlaanderen.be/id/conceptscheme/BesluitDocumentType> a <http://www.w3.org/2004/02/skos/core#ConceptScheme>;
   <http://www.w3.org/2004/02/skos/core#definition> "Het type van het document. Bijvoorbeeld: besluitenlijst, agenda,....";
   <http://www.w3.org/2004/02/skos/core#prefLabel> "besluit document type" .


### PR DESCRIPTION
# Description

DL-5498 & DL-5499

This PR adds three new besluitDocumentTypes for `LEKP-rapport - Sloopbeleidsplan`, `LEKP-rapport - Collectieve renovatie` and  `LEKP-rapport - Fietspaden`

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

# Related services

- N/A

# How to test 

- N/A
 
# What to check

- N/A 

# Links to other PR's

- https://github.com/lblod/manage-submission-form-tooling/pull/40
- https://github.com/lblod/enrich-submission-service/pull/16
- https://github.com/lblod/app-meldingsplichtige-api/pull/38
- https://github.com/lblod/app-digitaal-loket/pull/502
- https://github.com/lblod/app-public-decisions-database/pull/21
- https://github.com/lblod/app-worship-decisions-database/pull/53
- https://github.com/lblod/app-toezicht-abb/pull/35

# Notes

- N/A